### PR TITLE
CLI Option to add compatibility for old AKK VTX

### DIFF
--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -38,6 +38,7 @@
 #define VTX_SETTINGS_DEFAULT_FREQ               5740
 #define VTX_SETTINGS_DEFAULT_PITMODE_FREQ       0
 #define VTX_SETTINGS_DEFAULT_LOW_POWER_DISARM   0
+#define VTX_SETTINGS_DEFAULT_AKK_HACK           0
 
 #define VTX_SETTINGS_MAX_FREQUENCY_MHZ 5999          //max freq (in MHz) for 'vtx_freq' setting
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -832,6 +832,7 @@ const clivalue_t valueTable[] = {
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHANNEL, VTX_SETTINGS_MAX_CHANNEL }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_POWER, VTX_SETTINGS_POWER_COUNT-1 }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
     { "vtx_low_power_disarm",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, lowPowerDisarm) },
+    { "vtx_akk_hack",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, akkStyleEndFrame) },
 #ifdef VTX_SETTINGS_FREQCMD
     { "vtx_freq",                   VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, freq) },
     { "vtx_pit_mode_freq",          VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQUENCY_MHZ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, pitModeFreq) },

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -50,6 +50,7 @@ PG_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig,
     .freq = VTX_SETTINGS_DEFAULT_FREQ,
     .pitModeFreq = VTX_SETTINGS_DEFAULT_PITMODE_FREQ,
     .lowPowerDisarm = VTX_SETTINGS_DEFAULT_LOW_POWER_DISARM,
+    .akkStyleEndFrame = VTX_SETTINGS_DEFAULT_AKK_HACK,
 );
 
 typedef enum {

--- a/src/main/io/vtx.h
+++ b/src/main/io/vtx.h
@@ -30,6 +30,7 @@ typedef struct vtxSettingsConfig_s {
     uint16_t freq;          // sets freq in MHz if band=0
     uint16_t pitModeFreq;   // sets out-of-range pitmode frequency
     uint8_t lowPowerDisarm; // min power while disarmed
+    uint8_t akkStyleEndFrame; // Fix for older AKK with 0x00 end frame
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -447,6 +447,9 @@ static void saSendFrame(uint8_t *buf, int len)
         serialWrite(smartAudioSerialPort, buf[i]);
     }
 
+    if (vtxSettingsConfig()->akkStyleEndFrame) {
+      serialWrite(smartAudioSerialPort, 0x00); // Added back to fix old AKK - breaks custom freq.
+    }
     sa_lastTransmissionMs = millis();
     saStat.pktsent++;
 }


### PR DESCRIPTION
All this PR really does is add back a line of code removed by Codeace when he was fixing the implementation of Custom Frequency selection for Smart Audio.

Yes this does break Custom Frequency selection but to me it is an unecessary feature that most pilots can live without.